### PR TITLE
Add AGENTS.md with cloud-specific development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+This is a static React portfolio website (no backend, no database, no API). Single service: Vite dev server.
+
+### Tech Stack
+
+- React 19, TypeScript 6, Vite 8, Tailwind CSS 4
+- Package manager: **Yarn** (classic v1, `yarn.lock` present)
+
+### Commands
+
+| Task | Command |
+|------|---------|
+| Install deps | `yarn install` |
+| Dev server | `yarn dev` (serves on `http://localhost:5173`) |
+| Type check | `npx tsc --noEmit` |
+| Build | `yarn build` (runs `tsc && vite build`, outputs to `dist/`) |
+| Preview build | `yarn preview` |
+
+### Notes
+
+- No linter or test framework is configured in the project. `tsc --noEmit` is the only static analysis available.
+- No backend or database services are required.
+- The `hook/` directory (containing `useToggle.tsx`) lives outside `src/` but is included in `tsconfig.json`'s `include` array.
+- Use `--host 0.0.0.0` with `yarn dev` when the dev server needs to be accessible from outside localhost (e.g., cloud agent browser testing).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud specific instructions for future agents, covering:

- Tech stack overview (React 19, TypeScript 6, Vite 8, Tailwind CSS 4, Yarn)
- Common dev commands (install, dev, type-check, build, preview)
- Non-obvious caveats (e.g. `hook/` dir outside `src/`, no test framework configured, `--host 0.0.0.0` for cloud browser testing)

### Environment Verification

All checks pass and the dev server runs correctly:

[portfolio_site_demo.mp4](https://cursor.com/agents/bc-0d27c716-8d07-4025-a77a-4f0950d3d901/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fportfolio_site_demo.mp4)

Portfolio site running on `localhost:5173` with smooth-scroll navigation working across all sections.

[Hero section](https://cursor.com/agents/bc-0d27c716-8d07-4025-a77a-4f0950d3d901/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhero_section.webp)
[Tech Stack section](https://cursor.com/agents/bc-0d27c716-8d07-4025-a77a-4f0950d3d901/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftechstack_section.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d27c716-8d07-4025-a77a-4f0950d3d901"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d27c716-8d07-4025-a77a-4f0950d3d901"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

